### PR TITLE
feat: persist run state and metrics in MySQL

### DIFF
--- a/yolo_task_manager_cn/manager.py
+++ b/yolo_task_manager_cn/manager.py
@@ -16,7 +16,7 @@ from ultralytics import YOLO
 
 from .storage.base import IStorage
 from .storage.mysql import MySQLRunStateStorage
-from .metrics import MetricsStorage
+from .metrics import MySQLMetricsStorage
 
 
 class YoloTaskManager(object):
@@ -42,7 +42,7 @@ class YoloTaskManager(object):
             max_workers = max(2, global_limit * 2)
         self.pool = ThreadPoolExecutor(max_workers=max_workers)
         # MySQL 持久化
-        self.metrics_db = MetricsStorage(**mysql_cfg)
+        self.metrics_db = MySQLMetricsStorage(**mysql_cfg)
         self.run_db = MySQLRunStateStorage(**mysql_cfg)
         # 从数据库加载历史 run 状态
         self._runs = self.run_db.load_all() or {}
@@ -152,7 +152,7 @@ class YoloTaskManager(object):
                 labels=getattr(results, "names", None),
             )
             # 更新状态
-state["final_model_path"] = str(saved_path)
+            state["final_model_path"] = str(saved_path)
             # 持久化到 MySQL
             self.run_db.save(
                 run_id,

--- a/yolo_task_manager_cn/storage/mysql.py
+++ b/yolo_task_manager_cn/storage/mysql.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""MySQL 运行状态存储实现。"""
+
+import json
+import threading
+
+
+class MySQLRunStateStorage(object):
+    """将训练任务的运行状态持久化到 MySQL。"""
+
+    def __init__(self, host, port, user, password, database, table="runs"):
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.database = database
+        self.table = table
+        self._conn = None
+        self._lock = threading.Lock()
+
+    def _get_connection(self):
+        """获取数据库连接，如未连接则创建。"""
+        if self._conn:
+            return self._conn
+        with self._lock:
+            if self._conn:
+                return self._conn
+            conn = None
+            try:
+                import pymysql
+                conn = pymysql.connect(
+                    host=self.host,
+                    port=self.port,
+                    user=self.user,
+                    password=self.password,
+                    database=self.database,
+                    charset="utf8mb4",
+                )
+            except Exception:
+                try:
+                    import mysql.connector
+                    conn = mysql.connector.connect(
+                        host=self.host,
+                        port=self.port,
+                        user=self.user,
+                        password=self.password,
+                        database=self.database,
+                        charset="utf8mb4",
+                    )
+                except Exception as e:
+                    raise RuntimeError("无法连接 MySQL: %s" % e)
+            cur = conn.cursor()
+            create_sql = (
+                "CREATE TABLE IF NOT EXISTS `%s` (" % self.table
+                + "run_id VARCHAR(64) PRIMARY KEY,"
+                + "data JSON,"
+                + "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"
+            )
+            cur.execute(create_sql)
+            cur.close()
+            self._conn = conn
+        return self._conn
+
+    def save(self, run_id, data):
+        """保存或更新运行状态。"""
+        conn = self._get_connection()
+        cur = conn.cursor()
+        try:
+            sql = (
+                "REPLACE INTO `%s` (run_id, data) VALUES (%%s, %%s)" % self.table
+            )
+            cur.execute(sql, (run_id, json.dumps(data, ensure_ascii=False)))
+            conn.commit()
+        finally:
+            cur.close()
+
+    def load_all(self):
+        """加载全部运行状态，返回字典。"""
+        conn = self._get_connection()
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT run_id, data FROM `%s`" % self.table)
+            rows = cur.fetchall()
+            result = {}
+            for run_id, data in rows:
+                try:
+                    result[run_id] = json.loads(data)
+                except Exception:
+                    result[run_id] = {}
+            return result
+        finally:
+            cur.close()


### PR DESCRIPTION
## Summary
- 使用 `MySQLRunStateStorage` 持久化训练运行状态
- 训练过程中指标写入 MySQL，支持掉电恢复

## Testing
- `python -m py_compile yolo_task_manager_cn/manager.py yolo_task_manager_cn/metrics.py yolo_task_manager_cn/storage/mysql.py yolo_task_manager_cn/storage/base.py yolo_task_manager_cn/storage/local_fs.py yolo_task_manager_cn/__init__.py`
- `pip install ultralytics --no-deps`
- `pip install pymysql mysql-connector-python`
- `pip show ultralytics`


------
https://chatgpt.com/codex/tasks/task_e_68997e021c4c8323a74bb5e473b94f09